### PR TITLE
By removing CMD in favor of ENTRYPOINT, you can treat the container a…

### DIFF
--- a/0.7.14/Dockerfile
+++ b/0.7.14/Dockerfile
@@ -13,4 +13,4 @@ RUN apt-get install unzip \
 
 WORKDIR /usr/cslang/cslang/cslang/bin/
 
-CMD ["sh","cslang"]
+ENTRYPOINT ["sh","cslang"]


### PR DESCRIPTION
…s an executable.

For example, if i want to run a flow and exit:
`sudo docker run --rm -ti cloudslang run --f ../../content/io/cloudslang/base/print/print_text.sl --i text=first_flow`

If i want to open a CS session:
`sudo docker run -ti cloudslang`

With CMD, the former is not possible without modifying the CMD args at run time.
