### PR TITLE
Adding Dockerfile for 0.9.50 version

### DIFF
--- a/0.9.50/Dockerfile
+++ b/0.9.50/Dockerfile
@@ -1,0 +1,15 @@
+FROM java:openjdk-7-jre
+
+MAINTAINER CloudSlang
+
+RUN groupadd -r cslang && useradd -r -g cslang cslang
+
+RUN mkdir -p /usr/cslang \
+  && cd /usr/cslang \
+  && wget "https://github.com/CloudSlang/cloud-slang/releases/download/cloudslang-0.9.50.0/cslang-cli-with-content.tar.gzip" \
+  && tar xvf cslang-cli-with-content.tar.gzip \
+  && rm cslang-cli-with-content.tar.gzip
+
+WORKDIR /usr/cslang/cslang/bin/
+
+ENTRYPOINT ["sh","cslang"]


### PR DESCRIPTION
Fixes #13 
- Adding Dockerfile for 0.9.50
- Updating the MAINTAINER clause from Meir Wahnon to CloudSlang team
